### PR TITLE
Suggesting not to add a hard coded camera zoom on scroll

### DIFF
--- a/EasyBuff.lua
+++ b/EasyBuff.lua
@@ -80,7 +80,7 @@ end
 function EasyBuff:OnPostClick(button, down)
 	-- Zoom out, because we have taken over this command...
 	-- @TODO: Make sure we know that's the command we have overridden.
-	CameraZoomOut(1);
+	-- CameraZoomOut(1);
 end
 
 


### PR DESCRIPTION
Some people rebind their scroll wheel and used fixed camera distances in various situations, and I think it would be better to not make the scroll zoom out by default.
Worst case, people can bind another key to zoom out their camera if needed while the @TODO gets implemented.